### PR TITLE
Add support for browser channels

### DIFF
--- a/PlaywrightTests/BrowserFixture.cs
+++ b/PlaywrightTests/BrowserFixture.cs
@@ -83,6 +83,15 @@ namespace PlaywrightTests
                 options.SlowMo = 100;
             }
 
+            string[] split = browserType.Split(':');
+
+            browserType = split[0];
+
+            if (split.Length > 1)
+            {
+                options.Channel = split[1];
+            }
+
             return await playwright[browserType].LaunchAsync(options);
         }
 

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -12,6 +12,13 @@ namespace PlaywrightTests
         public IEnumerator<object[]> GetEnumerator()
         {
             yield return new object[] { "chromium" };
+            yield return new object[] { "chromium:chrome" };
+
+            if (!OperatingSystem.IsLinux())
+            {
+                yield return new object[] { "chromium:msedge" };
+            }
+
             yield return new object[] { "firefox" };
 
             if (OperatingSystem.IsMacOS())


### PR DESCRIPTION
  * Add support for specific browser channels, such as Google Chrome and Microsoft Edge.
  * Also given recorded videos test-specific names instead of their default random names.
