### PR TITLE
Update Microsoft.Playwright

### DIFF
--- a/PlaywrightTests/BrowserFixture.cs
+++ b/PlaywrightTests/BrowserFixture.cs
@@ -66,7 +66,6 @@ namespace PlaywrightTests
             if (IsRunningInGitHubActions)
             {
                 options.RecordVideoDir = "videos";
-                options.RecordVideoSize = new RecordVideoSize() { Width = 800, Height = 600 };
             }
 
             return options;
@@ -103,7 +102,7 @@ namespace PlaywrightTests
                 OperatingSystem.IsWindows() ? "windows" :
                 "other";
 
-            browserType = browserType.Replace(":", string.Empty, StringComparison.Ordinal);
+            browserType = browserType.Replace(':', '_');
 
             string utcNow = DateTimeOffset.UtcNow.ToString("yyyy-MM-dd-HH-mm-ss", CultureInfo.InvariantCulture);
             return $"{testName}_{browserType}_{os}_{utcNow}{extension}";

--- a/PlaywrightTests/PlaywrightTests.csproj
+++ b/PlaywrightTests/PlaywrightTests.csproj
@@ -6,7 +6,7 @@
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Playwright" Version="1.11.1-alpha-2" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.12.0-alpha-5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />


### PR DESCRIPTION
* Update to the latest release of Microsoft.Playwright and remove workaround for bug that's been fixed.
* Improve test naming when channels used.
