### PR TITLE
Use BrowserType constants and use C# 10 features

### DIFF
--- a/PlaywrightTests/BrowserFixture.cs
+++ b/PlaywrightTests/BrowserFixture.cs
@@ -1,11 +1,8 @@
 // Copyright (c) Martin Costello, 2021. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Globalization;
-using System.IO;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using Microsoft.Playwright;
 using Xunit.Abstractions;
 

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Martin Costello, 2021. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using Microsoft.Playwright;
 
 namespace PlaywrightTests

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Microsoft.Playwright;
 
 namespace PlaywrightTests
 {
@@ -11,23 +12,23 @@ namespace PlaywrightTests
     {
         public IEnumerator<object[]> GetEnumerator()
         {
-            yield return new object[] { "chromium" };
+            yield return new[] { BrowserType.Chromium };
 
             if (!OperatingSystem.IsWindows())
             {
-                yield return new object[] { "chromium:chrome" };
+                yield return new[] { BrowserType.Chromium + ":chrome" };
             }
 
             if (!OperatingSystem.IsLinux())
             {
-                yield return new object[] { "chromium:msedge" };
+                yield return new[] { BrowserType.Chromium + ":msedge" };
             }
 
-            yield return new object[] { "firefox" };
+            yield return new object[] { BrowserType.Firefox };
 
             if (OperatingSystem.IsMacOS())
             {
-                yield return new object[] { "webkit" };
+                yield return new object[] { BrowserType.Webkit };
             }
         }
 

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -4,32 +4,31 @@
 using System.Collections;
 using Microsoft.Playwright;
 
-namespace PlaywrightTests
+namespace PlaywrightTests;
+
+public sealed class BrowsersTestData : IEnumerable<object[]>
 {
-    public sealed class BrowsersTestData : IEnumerable<object[]>
+    public IEnumerator<object[]> GetEnumerator()
     {
-        public IEnumerator<object[]> GetEnumerator()
+        yield return new[] { BrowserType.Chromium };
+
+        if (!OperatingSystem.IsWindows())
         {
-            yield return new[] { BrowserType.Chromium };
-
-            if (!OperatingSystem.IsWindows())
-            {
-                yield return new[] { BrowserType.Chromium + ":chrome" };
-            }
-
-            if (!OperatingSystem.IsLinux())
-            {
-                yield return new[] { BrowserType.Chromium + ":msedge" };
-            }
-
-            yield return new object[] { BrowserType.Firefox };
-
-            if (OperatingSystem.IsMacOS())
-            {
-                yield return new object[] { BrowserType.Webkit };
-            }
+            yield return new[] { BrowserType.Chromium + ":chrome" };
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        if (!OperatingSystem.IsLinux())
+        {
+            yield return new[] { BrowserType.Chromium + ":msedge" };
+        }
+
+        yield return new object[] { BrowserType.Firefox };
+
+        if (OperatingSystem.IsMacOS())
+        {
+            yield return new object[] { BrowserType.Webkit };
+        }
     }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/PlaywrightTests/PlaywrightTests.csproj
+++ b/PlaywrightTests/PlaywrightTests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/PlaywrightTests/SearchTests.cs
+++ b/PlaywrightTests/SearchTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Martin Costello, 2021. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System.Threading.Tasks;
 using Microsoft.Playwright;
 using Xunit;
 using Xunit.Abstractions;

--- a/PlaywrightTests/SearchTests.cs
+++ b/PlaywrightTests/SearchTests.cs
@@ -25,11 +25,11 @@ public class SearchTests
         await browser.WithPageAsync(browserType, async (page) =>
         {
             // Open the search engine
-            await page.GotoAsync("https://www.bing.com/");
+            await page.GotoAsync("https://www.google.com/");
             await page.WaitForLoadStateAsync();
 
             // Dismiss any cookies dialog
-            IElementHandle element = await page.QuerySelectorAsync("id=bnp_btn_accept");
+            IElementHandle element = await page.QuerySelectorAsync("text='I agree'");
 
             if (element is not null)
             {
@@ -41,10 +41,10 @@ public class SearchTests
             await page.Keyboard.PressAsync("Enter");
 
             // Wait for the results to load
-            await page.WaitForSelectorAsync("id=b_content");
+            await page.WaitForSelectorAsync("id=main");
 
             // Click through to the desired result
-            await page.ClickAsync("a:has-text(\".NET Core\")");
+            await page.ClickAsync("a:has-text(\".NET\")");
         });
     }
 }


### PR DESCRIPTION
* Use the `BrowserType` constants for the browser names.
* Enable the use of C# 10 implicit using statements.
* Switch to file-scoped namespaces.
* Use Google instead of Bing.
