### PR TITLE
Support BrowserStack Automate

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,8 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.cs]
+csharp_style_namespace_declarations = file_scoped
+
 [*.{csproj,json,props}]
 indent_size = 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,12 @@ jobs:
       run: |
         dotnet tool install --global Microsoft.Playwright.CLI
 
+    - name: Configure BrowserStack credentials
+      if: ${{ github.repository_owner == 'martincostello' }}
+      run: |
+        echo "BROWSERSTACK_USERNAME=${{ secrets.BROWSERSTACK_USERNAME }}" >> $GITHUB_ENV
+        echo "BROWSERSTACK_TOKEN=${{ secrets.BROWSERSTACK_TOKEN }}" >> $GITHUB_ENV
+
     - name: Build and Test
       shell: pwsh
       run: ./build.ps1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,16 +31,15 @@ jobs:
 
     - name: Configure BrowserStack credentials
       if: ${{ github.repository_owner == 'martincostello' }}
+      shell: pwsh
       run: |
-        echo "BROWSERSTACK_USERNAME=${{ secrets.BROWSERSTACK_USERNAME }}" >> $GITHUB_ENV
-        echo "BROWSERSTACK_TOKEN=${{ secrets.BROWSERSTACK_TOKEN }}" >> $GITHUB_ENV
+        Write-Output "BROWSERSTACK_USERNAME=${{ secrets.BROWSERSTACK_USERNAME }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        Write-Output "BROWSERSTACK_TOKEN=${{ secrets.BROWSERSTACK_TOKEN }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Build and Test
       shell: pwsh
       run: ./build.ps1
       env:
-        BROWSERSTACK_USERNAME: ${{ env.BROWSERSTACK_USERNAME }}
-        BROWSERSTACK_TOKEN: ${{ env.BROWSERSTACK_TOKEN }}
         DOTNET_CLI_TELEMETRY_OPTOUT: true
         DOTNET_NOLOGO: true
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         dotnet tool install --global Microsoft.Playwright.CLI
 
     - name: Configure BrowserStack credentials
-      if: ${{ github.repository_owner == 'martincostello' }}
+      if: ${{ github.repository_owner == 'martincostello' && github.actor == 'martincostello' }}
       shell: pwsh
       run: |
         Write-Output "BROWSERSTACK_USERNAME=${{ secrets.BROWSERSTACK_USERNAME }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
       shell: pwsh
       run: ./build.ps1
       env:
+        BROWSERSTACK_USERNAME: {{ $env:BROWSERSTACK_USERNAME }}
+        BROWSERSTACK_TOKEN: {{ $env:BROWSERSTACK_TOKEN }}
         DOTNET_CLI_TELEMETRY_OPTOUT: true
         DOTNET_NOLOGO: true
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ jobs:
   build:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    concurrency: browserstack_automate # Prevent multiple jobs from trying to use BrowserStack Automate at the same time
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,8 @@ jobs:
       shell: pwsh
       run: ./build.ps1
       env:
-        BROWSERSTACK_USERNAME: {{ $env:BROWSERSTACK_USERNAME }}
-        BROWSERSTACK_TOKEN: {{ $env:BROWSERSTACK_TOKEN }}
+        BROWSERSTACK_USERNAME: ${{ env.BROWSERSTACK_USERNAME }}
+        BROWSERSTACK_TOKEN: ${{ env.BROWSERSTACK_TOKEN }}
         DOTNET_CLI_TELEMETRY_OPTOUT: true
         DOTNET_NOLOGO: true
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    concurrency: browserstack_automate # Prevent multiple jobs from trying to use BrowserStack Automate at the same time
 
     strategy:
       fail-fast: false

--- a/PlaywrightTests/BrowserFixture.cs
+++ b/PlaywrightTests/BrowserFixture.cs
@@ -219,7 +219,7 @@ public class BrowserFixture
         IPage page,
         string testName)
     {
-        if (!BrowsersTestData.IsRunningInGitHubActions)
+        if (!BrowsersTestData.IsRunningInGitHubActions || BrowsersTestData.UseBrowserStack)
         {
             return;
         }

--- a/PlaywrightTests/BrowserFixture.cs
+++ b/PlaywrightTests/BrowserFixture.cs
@@ -131,6 +131,7 @@ public class BrowserFixture
                 ["name"] = Options.TestName ?? testName,
                 ["os"] = Options.OperatingSystem,
                 ["os_version"] = Options.OperatingSystemVersion,
+                ["project"] = Options.ProjectName,
             };
 
             // Serialize the capabilities as a JSON blob and pass to the

--- a/PlaywrightTests/BrowserFixture.cs
+++ b/PlaywrightTests/BrowserFixture.cs
@@ -126,12 +126,12 @@ public class BrowserFixture
                 ["browser"] = browser,
                 ["browserstack.accessKey"] = Options.BrowserStackCredentials.AccessKey,
                 ["browserstack.username"] = Options.BrowserStackCredentials.UserName,
-                ["build"] = Options.Build,
+                ["build"] = Options.Build ?? GetDefaultBuildNumber(),
                 ["client.playwrightVersion"] = playwrightVersion,
                 ["name"] = Options.TestName ?? testName,
                 ["os"] = Options.OperatingSystem,
                 ["os_version"] = Options.OperatingSystemVersion,
-                ["project"] = Options.ProjectName,
+                ["project"] = Options.ProjectName ?? GetDefaultProject(),
             };
 
             // Serialize the capabilities as a JSON blob and pass to the
@@ -149,6 +149,30 @@ public class BrowserFixture
         }
 
         return await browserType.LaunchAsync(options);
+    }
+
+    private static string GetDefaultBuildNumber()
+    {
+        string build = Environment.GetEnvironmentVariable("GITHUB_RUN_NUMBER");
+
+        if (!string.IsNullOrEmpty(build))
+        {
+            return build;
+        }
+
+        return typeof(BrowserFixture).Assembly.GetName().Version.ToString(3);
+    }
+
+    private static string GetDefaultProject()
+    {
+        string project = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
+
+        if (!string.IsNullOrEmpty(project))
+        {
+            return project.Split('/')[1];
+        }
+
+        return "dotnet-playwright-tests";
     }
 
     private string GenerateFileName(string testName, string extension)

--- a/PlaywrightTests/BrowserFixture.cs
+++ b/PlaywrightTests/BrowserFixture.cs
@@ -20,8 +20,6 @@ public class BrowserFixture
         OutputHelper = outputHelper;
     }
 
-    private static bool IsRunningInGitHubActions { get; } = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
-
     private BrowserFixtureOptions Options { get; }
 
     private ITestOutputHelper OutputHelper { get; }
@@ -66,7 +64,7 @@ public class BrowserFixture
             TimezoneId = "Europe/London",
         };
 
-        if (IsRunningInGitHubActions)
+        if (BrowsersTestData.IsRunningInGitHubActions)
         {
             options.RecordVideoDir = Path.GetTempPath();
         }
@@ -221,7 +219,7 @@ public class BrowserFixture
         IPage page,
         string testName)
     {
-        if (!IsRunningInGitHubActions)
+        if (!BrowsersTestData.IsRunningInGitHubActions)
         {
             return;
         }

--- a/PlaywrightTests/BrowserFixture.cs
+++ b/PlaywrightTests/BrowserFixture.cs
@@ -72,9 +72,7 @@ public class BrowserFixture
         return options;
     }
 
-    private async Task<IBrowser> CreateBrowserAsync(
-        IPlaywright playwright,
-        [CallerMemberName] string testName = null)
+    private async Task<IBrowser> CreateBrowserAsync(IPlaywright playwright, string testName)
     {
         var options = new BrowserTypeLaunchOptions()
         {

--- a/PlaywrightTests/BrowserFixture.cs
+++ b/PlaywrightTests/BrowserFixture.cs
@@ -219,6 +219,8 @@ public class BrowserFixture
         IPage page,
         string testName)
     {
+        // HACK The call to SaveAsAsync() hangs when used with BrowserStack.
+        // https://github.com/martincostello/dotnet-playwright-tests/pull/34#issuecomment-1018689977
         if (!BrowsersTestData.IsRunningInGitHubActions || BrowsersTestData.UseBrowserStack)
         {
             return;

--- a/PlaywrightTests/BrowserFixtureOptions.cs
+++ b/PlaywrightTests/BrowserFixtureOptions.cs
@@ -39,6 +39,11 @@ public class BrowserFixtureOptions
     public string PlaywrightVersion { get; set; }
 
     /// <summary>
+    /// Gets or sets the optional project name.
+    /// </summary>
+    public string ProjectName { get; set; }
+
+    /// <summary>
     /// Gets or sets the optional test name.
     /// </summary>
     public string TestName { get; set; }

--- a/PlaywrightTests/BrowserFixtureOptions.cs
+++ b/PlaywrightTests/BrowserFixtureOptions.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Martin Costello, 2021. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace PlaywrightTests;
+
+/// <summary>
+/// A class representing the options to use with <see cref="BrowserFixture"/>.
+/// </summary>
+public class BrowserFixtureOptions
+{
+    /// <summary>
+    /// Gets or sets the browser type.
+    /// </summary>
+    public string BrowserType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional browser channel.
+    /// </summary>
+    public string BrowserChannel { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional build number.
+    /// </summary>
+    public string Build { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional operating system name.
+    /// </summary>
+    public string OperatingSystem { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional operating system version.
+    /// </summary>
+    public string OperatingSystemVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional Playwright version number.
+    /// </summary>
+    public string PlaywrightVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional test name.
+    /// </summary>
+    public string TestName { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use BrowserStack.
+    /// </summary>
+    public bool UseBrowserStack { get; set; }
+
+    /// <summary>
+    /// Gets or sets the credentials to use to connect to BrowserStack.
+    /// </summary>
+    public (string UserName, string AccessKey) BrowserStackCredentials { get; set; }
+
+    /// <summary>
+    /// Gets or sets the URI of the WS endpoint to use to connect to BrowserStack.
+    /// </summary>
+    public Uri BrowserStackEndpoint { get; set; } = new("wss://cdp.browserstack.com/playwright", UriKind.Absolute);
+}

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -16,9 +16,17 @@ public sealed class BrowsersTestData : IEnumerable<object[]>
         return (browserStackUserName, browserStackToken);
     }
 
+    public static bool IsRunningInGitHubActions { get; } = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
+
     public IEnumerator<object[]> GetEnumerator()
     {
         bool useBrowserStack = BrowserStackCredentials() != default;
+
+        // HACK Something is hanging when using BrowserStack on non-Windows operating systems in GitHub Actions
+        if (useBrowserStack && IsRunningInGitHubActions && !OperatingSystem.IsWindows())
+        {
+            useBrowserStack = false;
+        }
 
         yield return new[] { BrowserType.Chromium, null };
 

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -12,22 +12,22 @@ public sealed class BrowsersTestData : IEnumerable<object[]>
     {
         yield return new[] { BrowserType.Chromium, null };
 
-        if (!OperatingSystem.IsWindows())
-        {
-            yield return new[] { BrowserType.Chromium, "chrome" };
-        }
-
-        if (!OperatingSystem.IsLinux())
-        {
-            yield return new[] { BrowserType.Chromium, "msedge" };
-        }
-
-        yield return new object[] { BrowserType.Firefox, null };
-
-        if (OperatingSystem.IsMacOS())
-        {
-            yield return new object[] { BrowserType.Webkit, null };
-        }
+        ///if (!OperatingSystem.IsWindows())
+        ///{
+        ///    yield return new[] { BrowserType.Chromium, "chrome" };
+        ///}
+        ///
+        ///if (!OperatingSystem.IsLinux())
+        ///{
+        ///    yield return new[] { BrowserType.Chromium, "msedge" };
+        ///}
+        ///
+        ///yield return new object[] { BrowserType.Firefox, null };
+        ///
+        ///if (OperatingSystem.IsMacOS())
+        ///{
+        ///    yield return new object[] { BrowserType.Webkit, null };
+        ///}
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -8,6 +8,10 @@ namespace PlaywrightTests;
 
 public sealed class BrowsersTestData : IEnumerable<object[]>
 {
+    public static bool IsRunningInGitHubActions { get; } = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
+
+    public static bool UseBrowserStack => UseBrowserStackForTests();
+
     public static (string UserName, string AccessToken) BrowserStackCredentials()
     {
         string browserStackUserName = Environment.GetEnvironmentVariable("BROWSERSTACK_USERNAME");
@@ -16,27 +20,25 @@ public sealed class BrowsersTestData : IEnumerable<object[]>
         return (browserStackUserName, browserStackToken);
     }
 
-    public static bool IsRunningInGitHubActions { get; } = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
-
-    public static bool UseBrowserStack { get; } = UseBrowserStackForTests();
-
     public IEnumerator<object[]> GetEnumerator()
     {
+        bool useBrowserStack = UseBrowserStack;
+
         yield return new[] { BrowserType.Chromium, null };
 
-        if (UseBrowserStack || !OperatingSystem.IsWindows())
+        if (useBrowserStack || !OperatingSystem.IsWindows())
         {
             yield return new[] { BrowserType.Chromium, "chrome" };
         }
 
-        if (UseBrowserStack || !OperatingSystem.IsLinux())
+        if (useBrowserStack || !OperatingSystem.IsLinux())
         {
             yield return new[] { BrowserType.Chromium, "msedge" };
         }
 
         yield return new object[] { BrowserType.Firefox, null };
 
-        if (UseBrowserStack || OperatingSystem.IsMacOS())
+        if (useBrowserStack || OperatingSystem.IsMacOS())
         {
             yield return new object[] { BrowserType.Webkit, null };
         }

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -51,10 +51,10 @@ public sealed class BrowsersTestData : IEnumerable<object[]>
         bool useBrowserStack = BrowserStackCredentials() != default;
 
         // HACK Something is hanging when using BrowserStack on non-Windows operating systems in GitHub Actions
-        ////if (useBrowserStack && IsRunningInGitHubActions && !OperatingSystem.IsWindows())
-        ////{
-        ////    useBrowserStack = false;
-        ////}
+        if (useBrowserStack && IsRunningInGitHubActions)
+        {
+            useBrowserStack = OperatingSystem.IsWindows();
+        }
 
         return useBrowserStack;
     }

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -14,10 +14,10 @@ public sealed class BrowsersTestData : IEnumerable<object[]>
 
     public static (string UserName, string AccessToken) BrowserStackCredentials()
     {
-        string browserStackUserName = Environment.GetEnvironmentVariable("BROWSERSTACK_USERNAME");
-        string browserStackToken = Environment.GetEnvironmentVariable("BROWSERSTACK_TOKEN");
+        string userName = Environment.GetEnvironmentVariable("BROWSERSTACK_USERNAME");
+        string accessToken = Environment.GetEnvironmentVariable("BROWSERSTACK_TOKEN");
 
-        return (browserStackUserName, browserStackToken);
+        return (userName, accessToken);
     }
 
     public IEnumerator<object[]> GetEnumerator()

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -12,22 +12,22 @@ public sealed class BrowsersTestData : IEnumerable<object[]>
     {
         yield return new[] { BrowserType.Chromium, null };
 
-        ///if (!OperatingSystem.IsWindows())
-        ///{
-        ///    yield return new[] { BrowserType.Chromium, "chrome" };
-        ///}
-        ///
-        ///if (!OperatingSystem.IsLinux())
-        ///{
-        ///    yield return new[] { BrowserType.Chromium, "msedge" };
-        ///}
-        ///
-        ///yield return new object[] { BrowserType.Firefox, null };
-        ///
-        ///if (OperatingSystem.IsMacOS())
-        ///{
-        ///    yield return new object[] { BrowserType.Webkit, null };
-        ///}
+        if (!OperatingSystem.IsWindows())
+        {
+            yield return new[] { BrowserType.Chromium, "chrome" };
+        }
+
+        if (!OperatingSystem.IsLinux())
+        {
+            yield return new[] { BrowserType.Chromium, "msedge" };
+        }
+
+        yield return new object[] { BrowserType.Firefox, null };
+
+        if (OperatingSystem.IsMacOS())
+        {
+            yield return new object[] { BrowserType.Webkit, null };
+        }
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -18,10 +18,7 @@ public sealed class BrowsersTestData : IEnumerable<object[]>
 
     public static bool IsRunningInGitHubActions { get; } = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
 
-    public static bool UseBrowserStack { get; } =
-        BrowserStackCredentials() != default &&
-        // HACK Something is hanging when using BrowserStack on non-Windows operating systems in GitHub Actions
-        (!IsRunningInGitHubActions || OperatingSystem.IsWindows());
+    public static bool UseBrowserStack { get; } = UseBrowserStackForTests();
 
     public IEnumerator<object[]> GetEnumerator()
     {
@@ -46,4 +43,17 @@ public sealed class BrowsersTestData : IEnumerable<object[]>
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private static bool UseBrowserStackForTests()
+    {
+        bool useBrowserStack = BrowserStackCredentials() != default;
+
+        // HACK Something is hanging when using BrowserStack on non-Windows operating systems in GitHub Actions
+        if (useBrowserStack && IsRunningInGitHubActions && !OperatingSystem.IsWindows())
+        {
+            useBrowserStack = false;
+        }
+
+        return useBrowserStack;
+    }
 }

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -51,10 +51,10 @@ public sealed class BrowsersTestData : IEnumerable<object[]>
         bool useBrowserStack = BrowserStackCredentials() != default;
 
         // HACK Something is hanging when using BrowserStack on non-Windows operating systems in GitHub Actions
-        if (useBrowserStack && IsRunningInGitHubActions && !OperatingSystem.IsWindows())
-        {
-            useBrowserStack = false;
-        }
+        ////if (useBrowserStack && IsRunningInGitHubActions && !OperatingSystem.IsWindows())
+        ////{
+        ////    useBrowserStack = false;
+        ////}
 
         return useBrowserStack;
     }

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -18,31 +18,28 @@ public sealed class BrowsersTestData : IEnumerable<object[]>
 
     public static bool IsRunningInGitHubActions { get; } = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
 
+    public static bool UseBrowserStack { get; } =
+        BrowserStackCredentials() != default &&
+        // HACK Something is hanging when using BrowserStack on non-Windows operating systems in GitHub Actions
+        (!IsRunningInGitHubActions || OperatingSystem.IsWindows());
+
     public IEnumerator<object[]> GetEnumerator()
     {
-        bool useBrowserStack = BrowserStackCredentials() != default;
-
-        // HACK Something is hanging when using BrowserStack on non-Windows operating systems in GitHub Actions
-        if (useBrowserStack && IsRunningInGitHubActions && !OperatingSystem.IsWindows())
-        {
-            useBrowserStack = false;
-        }
-
         yield return new[] { BrowserType.Chromium, null };
 
-        if (useBrowserStack || !OperatingSystem.IsWindows())
+        if (UseBrowserStack || !OperatingSystem.IsWindows())
         {
             yield return new[] { BrowserType.Chromium, "chrome" };
         }
 
-        if (useBrowserStack || !OperatingSystem.IsLinux())
+        if (UseBrowserStack || !OperatingSystem.IsLinux())
         {
             yield return new[] { BrowserType.Chromium, "msedge" };
         }
 
         yield return new object[] { BrowserType.Firefox, null };
 
-        if (useBrowserStack || OperatingSystem.IsMacOS())
+        if (UseBrowserStack || OperatingSystem.IsMacOS())
         {
             yield return new object[] { BrowserType.Webkit, null };
         }

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -10,23 +10,23 @@ public sealed class BrowsersTestData : IEnumerable<object[]>
 {
     public IEnumerator<object[]> GetEnumerator()
     {
-        yield return new[] { BrowserType.Chromium };
+        yield return new[] { BrowserType.Chromium, null };
 
         if (!OperatingSystem.IsWindows())
         {
-            yield return new[] { BrowserType.Chromium + ":chrome" };
+            yield return new[] { BrowserType.Chromium, "chrome" };
         }
 
         if (!OperatingSystem.IsLinux())
         {
-            yield return new[] { BrowserType.Chromium + ":msedge" };
+            yield return new[] { BrowserType.Chromium, "msedge" };
         }
 
-        yield return new object[] { BrowserType.Firefox };
+        yield return new object[] { BrowserType.Firefox, null };
 
         if (OperatingSystem.IsMacOS())
         {
-            yield return new object[] { BrowserType.Webkit };
+            yield return new object[] { BrowserType.Webkit, null };
         }
     }
 

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -8,23 +8,33 @@ namespace PlaywrightTests;
 
 public sealed class BrowsersTestData : IEnumerable<object[]>
 {
+    public static (string UserName, string AccessToken) BrowserStackCredentials()
+    {
+        string browserStackUserName = Environment.GetEnvironmentVariable("BROWSERSTACK_USERNAME");
+        string browserStackToken = Environment.GetEnvironmentVariable("BROWSERSTACK_TOKEN");
+
+        return (browserStackUserName, browserStackToken);
+    }
+
     public IEnumerator<object[]> GetEnumerator()
     {
+        bool useBrowserStack = BrowserStackCredentials() != default;
+
         yield return new[] { BrowserType.Chromium, null };
 
-        if (!OperatingSystem.IsWindows())
+        if (useBrowserStack || !OperatingSystem.IsWindows())
         {
             yield return new[] { BrowserType.Chromium, "chrome" };
         }
 
-        if (!OperatingSystem.IsLinux())
+        if (useBrowserStack || !OperatingSystem.IsLinux())
         {
             yield return new[] { BrowserType.Chromium, "msedge" };
         }
 
         yield return new object[] { BrowserType.Firefox, null };
 
-        if (OperatingSystem.IsMacOS())
+        if (useBrowserStack || OperatingSystem.IsMacOS())
         {
             yield return new object[] { BrowserType.Webkit, null };
         }

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -10,7 +10,7 @@ public sealed class BrowsersTestData : IEnumerable<object[]>
 {
     public static bool IsRunningInGitHubActions { get; } = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
 
-    public static bool UseBrowserStack => UseBrowserStackForTests();
+    public static bool UseBrowserStack => BrowserStackCredentials() != default;
 
     public static (string UserName, string AccessToken) BrowserStackCredentials()
     {
@@ -45,17 +45,4 @@ public sealed class BrowsersTestData : IEnumerable<object[]>
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-    private static bool UseBrowserStackForTests()
-    {
-        bool useBrowserStack = BrowserStackCredentials() != default;
-
-        // HACK Something is hanging when using BrowserStack on non-Windows operating systems in GitHub Actions
-        if (useBrowserStack && IsRunningInGitHubActions)
-        {
-            useBrowserStack = OperatingSystem.IsWindows();
-        }
-
-        return useBrowserStack;
-    }
 }

--- a/PlaywrightTests/PlaywrightTests.csproj
+++ b/PlaywrightTests/PlaywrightTests.csproj
@@ -7,6 +7,7 @@
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.18.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/PlaywrightTests/SearchTests.cs
+++ b/PlaywrightTests/SearchTests.cs
@@ -27,12 +27,9 @@ public class SearchTests
             BrowserChannel = browserChannel,
         };
 
-        // Use BrowserStack if credentials are configured
-        var credentials = BrowsersTestData.BrowserStackCredentials();
-
-        if (credentials != default)
+        if (BrowsersTestData.UseBrowserStack)
         {
-            options.BrowserStackCredentials = credentials;
+            options.BrowserStackCredentials = BrowsersTestData.BrowserStackCredentials();
             options.UseBrowserStack = true;
         }
 

--- a/PlaywrightTests/SearchTests.cs
+++ b/PlaywrightTests/SearchTests.cs
@@ -16,7 +16,7 @@ public class SearchTests
 
     private ITestOutputHelper OutputHelper { get; }
 
-    [Theory]
+    [Theory(Timeout = 30_000)]
     [ClassData(typeof(BrowsersTestData))]
     public async Task Search_For_DotNet_Core(string browserType, string browserChannel)
     {

--- a/PlaywrightTests/SearchTests.cs
+++ b/PlaywrightTests/SearchTests.cs
@@ -18,11 +18,30 @@ public class SearchTests
 
     [Theory]
     [ClassData(typeof(BrowsersTestData))]
-    public async Task Search_For_DotNet_Core(string browserType)
+    public async Task Search_For_DotNet_Core(string browserType, string browserChannel)
     {
+        // Configure the options to use with the fixture for this test
+        var options = new BrowserFixtureOptions()
+        {
+            BrowserType = browserType,
+            BrowserChannel = browserChannel,
+            Build = GetType().Assembly.GetName().Version.ToString(3),
+        };
+
+        // Use BrowserStack if credentials are configured
+        string browserStackUserName = Environment.GetEnvironmentVariable("BROWSERSTACK_USERNAME");
+        string browserStackToken = Environment.GetEnvironmentVariable("BROWSERSTACK_TOKEN");
+
+        if (!string.IsNullOrEmpty(browserStackUserName) &&
+            !string.IsNullOrEmpty(browserStackToken))
+        {
+            options.BrowserStackCredentials = (browserStackUserName, browserStackToken);
+            options.UseBrowserStack = true;
+        }
+
         // Create fixture that will provide an IPage to use for the test
-        var browser = new BrowserFixture(OutputHelper);
-        await browser.WithPageAsync(browserType, async (page) =>
+        var browser = new BrowserFixture(options, OutputHelper);
+        await browser.WithPageAsync(async (page) =>
         {
             // Open the search engine
             await page.GotoAsync("https://www.google.com/");

--- a/PlaywrightTests/SearchTests.cs
+++ b/PlaywrightTests/SearchTests.cs
@@ -28,13 +28,11 @@ public class SearchTests
         };
 
         // Use BrowserStack if credentials are configured
-        string browserStackUserName = Environment.GetEnvironmentVariable("BROWSERSTACK_USERNAME");
-        string browserStackToken = Environment.GetEnvironmentVariable("BROWSERSTACK_TOKEN");
+        var credentials = BrowsersTestData.BrowserStackCredentials();
 
-        if (!string.IsNullOrEmpty(browserStackUserName) &&
-            !string.IsNullOrEmpty(browserStackToken))
+        if (credentials != default)
         {
-            options.BrowserStackCredentials = (browserStackUserName, browserStackToken);
+            options.BrowserStackCredentials = credentials;
             options.UseBrowserStack = true;
         }
 

--- a/PlaywrightTests/SearchTests.cs
+++ b/PlaywrightTests/SearchTests.cs
@@ -20,6 +20,11 @@ public class SearchTests
     [ClassData(typeof(BrowsersTestData))]
     public async Task Search_For_DotNet_Core(string browserType, string browserChannel)
     {
+        OutputHelper.WriteLine("BrowserStack UserName Present: {0}", !string.IsNullOrWhiteSpace(BrowsersTestData.BrowserStackCredentials().UserName));
+        OutputHelper.WriteLine("BrowserStack AccessToken Present: {0}", !string.IsNullOrWhiteSpace(BrowsersTestData.BrowserStackCredentials().AccessToken));
+        OutputHelper.WriteLine("BrowsersTestData.IsRunningInGitHubActions: {0}", BrowsersTestData.IsRunningInGitHubActions);
+        OutputHelper.WriteLine("OperatingSystem.IsWindows(): {0}", OperatingSystem.IsWindows());
+
         // Configure the options to use with the fixture for this test
         var options = new BrowserFixtureOptions()
         {

--- a/PlaywrightTests/SearchTests.cs
+++ b/PlaywrightTests/SearchTests.cs
@@ -23,6 +23,8 @@ public class SearchTests
         OutputHelper.WriteLine("BrowserStack UserName Present: {0}", !string.IsNullOrWhiteSpace(BrowsersTestData.BrowserStackCredentials().UserName));
         OutputHelper.WriteLine("BrowserStack AccessToken Present: {0}", !string.IsNullOrWhiteSpace(BrowsersTestData.BrowserStackCredentials().AccessToken));
         OutputHelper.WriteLine("BrowsersTestData.IsRunningInGitHubActions: {0}", BrowsersTestData.IsRunningInGitHubActions);
+        OutputHelper.WriteLine("BrowsersTestData.UseBrowserStack: {0}", BrowsersTestData.UseBrowserStack);
+        OutputHelper.WriteLine("BrowsersTestData.BrowserStackCredentials() != default: {0}", BrowsersTestData.BrowserStackCredentials() != default);
         OutputHelper.WriteLine("OperatingSystem.IsWindows(): {0}", OperatingSystem.IsWindows());
 
         // Configure the options to use with the fixture for this test

--- a/PlaywrightTests/SearchTests.cs
+++ b/PlaywrightTests/SearchTests.cs
@@ -25,8 +25,6 @@ public class SearchTests
         {
             BrowserType = browserType,
             BrowserChannel = browserChannel,
-            Build = GetType().Assembly.GetName().Version.ToString(3),
-            ProjectName = "dotnet-playwright-tests",
         };
 
         // Use BrowserStack if credentials are configured

--- a/PlaywrightTests/SearchTests.cs
+++ b/PlaywrightTests/SearchTests.cs
@@ -20,13 +20,6 @@ public class SearchTests
     [ClassData(typeof(BrowsersTestData))]
     public async Task Search_For_DotNet_Core(string browserType, string browserChannel)
     {
-        OutputHelper.WriteLine("BrowserStack UserName Present: {0}", !string.IsNullOrWhiteSpace(BrowsersTestData.BrowserStackCredentials().UserName));
-        OutputHelper.WriteLine("BrowserStack AccessToken Present: {0}", !string.IsNullOrWhiteSpace(BrowsersTestData.BrowserStackCredentials().AccessToken));
-        OutputHelper.WriteLine("BrowsersTestData.IsRunningInGitHubActions: {0}", BrowsersTestData.IsRunningInGitHubActions);
-        OutputHelper.WriteLine("BrowsersTestData.UseBrowserStack: {0}", BrowsersTestData.UseBrowserStack);
-        OutputHelper.WriteLine("BrowsersTestData.BrowserStackCredentials() != default: {0}", BrowsersTestData.BrowserStackCredentials() != default);
-        OutputHelper.WriteLine("OperatingSystem.IsWindows(): {0}", OperatingSystem.IsWindows());
-
         // Configure the options to use with the fixture for this test
         var options = new BrowserFixtureOptions()
         {

--- a/PlaywrightTests/SearchTests.cs
+++ b/PlaywrightTests/SearchTests.cs
@@ -26,6 +26,7 @@ public class SearchTests
             BrowserType = browserType,
             BrowserChannel = browserChannel,
             Build = GetType().Assembly.GetName().Version.ToString(3),
+            ProjectName = "dotnet-playwright-tests",
         };
 
         // Use BrowserStack if credentials are configured

--- a/PlaywrightTests/SearchTests.cs
+++ b/PlaywrightTests/SearchTests.cs
@@ -16,7 +16,7 @@ public class SearchTests
 
     private ITestOutputHelper OutputHelper { get; }
 
-    [Theory(Timeout = 30_000)]
+    [Theory(Timeout = 45_000)]
     [ClassData(typeof(BrowsersTestData))]
     public async Task Search_For_DotNet_Core(string browserType, string browserChannel)
     {

--- a/build.ps1
+++ b/build.ps1
@@ -1,2 +1,2 @@
 #! /usr/bin/pwsh
-dotnet test --configuration Release --output ./artifacts --logger "console;verbosity=detailed"
+dotnet test --configuration Release --output ./artifacts

--- a/build.ps1
+++ b/build.ps1
@@ -1,2 +1,2 @@
 #! /usr/bin/env pwsh
-dotnet test --configuration Release --output ./artifacts
+dotnet test --configuration Release --output ./artifacts --logger "console;verbosity=detailed"

--- a/build.ps1
+++ b/build.ps1
@@ -1,2 +1,2 @@
 #! /usr/bin/pwsh
-dotnet test --configuration Release --output ./artifacts
+dotnet test --configuration Release --output ./artifacts --logger "console;verbosity=detailed"

--- a/build.ps1
+++ b/build.ps1
@@ -1,2 +1,2 @@
 #! /usr/bin/env pwsh
-dotnet test --configuration Release --output ./artifacts --logger "console;verbosity=detailed"
+dotnet test --configuration Release --output ./artifacts

--- a/build.ps1
+++ b/build.ps1
@@ -1,2 +1,2 @@
-#! /usr/bin/pwsh
+#! /usr/bin/env pwsh
 dotnet test --configuration Release --output ./artifacts


### PR DESCRIPTION
Add support for BrowserStack Automate using the [`BrowserType.ConnectAsync()`](https://playwright.dev/dotnet/docs/api/class-browsertype#browser-type-connect) method added in Microsoft.Playwright [v1.18.0](https://github.com/microsoft/playwright-dotnet/releases/tag/v1.18.0) (from #33).

/cc @slang25
