### PR TITLE
Support videos in BrowserStack

### DIFF
--- a/PlaywrightTests/BrowserFixture.cs
+++ b/PlaywrightTests/BrowserFixture.cs
@@ -12,6 +12,8 @@ namespace PlaywrightTests;
 
 public class BrowserFixture
 {
+    private const string VideosDirectory = "videos";
+
     public BrowserFixture(
         BrowserFixtureOptions options,
         ITestOutputHelper outputHelper)
@@ -80,7 +82,12 @@ public class BrowserFixture
 
                 string extension = Path.GetExtension(response.Content.Headers.ContentDisposition.FileName);
                 string fileName = GenerateFileName(testName, extension);
-                string path = Path.Combine("videos", fileName);
+                string path = Path.Combine(VideosDirectory, fileName);
+
+                if (!Directory.Exists(path))
+                {
+                    Directory.CreateDirectory(VideosDirectory);
+                }
 
                 using var file = File.OpenWrite(path);
 
@@ -262,7 +269,7 @@ public class BrowserFixture
         try
         {
             string fileName = GenerateFileName(testName, ".webm");
-            string path = Path.Combine("videos", fileName);
+            string path = Path.Combine(VideosDirectory, fileName);
 
             if (BrowsersTestData.UseBrowserStack)
             {

--- a/PlaywrightTests/SearchTests.cs
+++ b/PlaywrightTests/SearchTests.cs
@@ -16,7 +16,7 @@ public class SearchTests
 
     private ITestOutputHelper OutputHelper { get; }
 
-    [Theory(Timeout = 45_000)]
+    [Theory(Timeout = 60_000)]
     [ClassData(typeof(BrowsersTestData))]
     public async Task Search_For_DotNet_Core(string browserType, string browserChannel)
     {

--- a/PlaywrightTests/SearchTests.cs
+++ b/PlaywrightTests/SearchTests.cs
@@ -16,7 +16,7 @@ public class SearchTests
 
     private ITestOutputHelper OutputHelper { get; }
 
-    [Theory(Timeout = 60_000)]
+    [Theory]
     [ClassData(typeof(BrowsersTestData))]
     public async Task Search_For_DotNet_Core(string browserType, string browserChannel)
     {


### PR DESCRIPTION
BrowserStack does not stop the video until the session ends, so any attempt to save the video while the browser is connected will just hang indefinitely https://github.com/martincostello/dotnet-playwright-tests/pull/34#issuecomment-1018689977.

Instead, get the video URL from the BrowserStack context and then download it after the browser session has ended.
