### PR TITLE
Enable colour output from .NET CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,9 @@ jobs:
         DOTNET_CLI_TELEMETRY_OPTOUT: true
         DOTNET_NOLOGO: true
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+        DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
         NUGET_XMLDOC_MODE: skip
+        TERM: xterm
 
     - name: Publish screenshots
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Enable coloured output to the terminal in GitHub Actions for Linux and macOS.

<!-- Summarise the changes this Pull Request makes. -->

<!-- Please include a reference to a GitHub issue if appropriate. -->
