### PR TITLE
Fix obsolete warning

### DIFF
--- a/PlaywrightTests/PlaywrightTests.csproj
+++ b/PlaywrightTests/PlaywrightTests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <TargetFramework>net7.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />

--- a/PlaywrightTests/SearchTests.cs
+++ b/PlaywrightTests/SearchTests.cs
@@ -66,7 +66,7 @@ public class SearchTests : IAsyncLifetime
             }
 
             // Search for the desired term
-            await page.TypeAsync("[name='q']", ".net core");
+            await page.FillAsync("[name='q']", ".net core");
             await page.ClickAsync("input[value='Google Search']");
 
             // Wait for the results to load


### PR DESCRIPTION
- Use `FillAsync()` instead of `TypeAsync()`.
- Enable `TreatWarningsAsErrors` to catch future errors at PR time in CI.
