### PR TITLE
Use actionlint Docker image

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,11 +30,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Add actionlint problem matcher
+      run: echo "::add-matcher::.github/actionlint-matcher.json"
+
     - name: Lint workflows
-      shell: bash
-      env:
-        ACTIONLINT_VERSION: '7b75d16d41920ec126e6f3269db0c6f3ab613c38' # v1.6.25
-      run: |
-        echo "::add-matcher::.github/actionlint-matcher.json"
-        bash <(curl --silent --show-error "https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_VERSION}/scripts/download-actionlint.bash")
-        ./actionlint -color
+      uses: docker://rhysd/actionlint@sha256:2eb91a78b5a19140be099c7b4262d298c2567f2a9f27e10ed2a4323c5bcface8 # v1.6.26
+      with:
+        args: -color

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -38,7 +38,7 @@ public sealed class BrowsersTestData : IEnumerable<object[]>
 
         yield return new object[] { BrowserType.Firefox, null };
 
-        if (useBrowserStack || OperatingSystem.IsMacOS())
+        if (/*useBrowserStack ||*/ OperatingSystem.IsMacOS())
         {
             yield return new object[] { BrowserType.Webkit, null };
         }

--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -38,10 +38,12 @@ public sealed class BrowsersTestData : IEnumerable<object[]>
 
         yield return new object[] { BrowserType.Firefox, null };
 
-        if (/*useBrowserStack ||*/ OperatingSystem.IsMacOS())
+        /*
+        if (useBrowserStack || OperatingSystem.IsMacOS())
         {
             yield return new object[] { BrowserType.Webkit, null };
         }
+        */
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();


### PR DESCRIPTION
- Use actionlint from a Docker image for consistency with other repos.
- Bump actionlint to v1.6.26.
