### PR TITLE
Disable Edge on macOS

### DIFF
--- a/PlaywrightTests/BrowsersTestData.cs
+++ b/PlaywrightTests/BrowsersTestData.cs
@@ -19,7 +19,7 @@ public sealed class BrowsersTestData : TheoryData<string, string>
             Add(BrowserType.Chromium, "chrome");
         }
 
-        if (useBrowserStack || !OperatingSystem.IsLinux())
+        if (useBrowserStack || OperatingSystem.IsWindows())
         {
             Add(BrowserType.Chromium, "msedge");
         }


### PR DESCRIPTION
The new macOS 14 runners do not have MS Edge installed.
